### PR TITLE
Add ChatGPT, Codex, and Codex CLI to the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,5 @@
-FROM ghcr.io/xtruder/nix-devcontainer:v1
+FROM ghcr.io/rails/devcontainer/images/ruby:3.4.8
 
-RUN echo "Dev environment ready." > ~/greeting.txt
-
-# cache /nix
-VOLUME /nix
+RUN curl -fsSL https://chatgpt.com/codex/install.sh | \
+    CODEX_NON_INTERACTIVE=1 sh \
+    && "$HOME/.local/bin/codex" --version

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    },
+    "ghcr.io/rails/devcontainer/features/postgres-client:1.1.3": {
+      "version": "1.1.3",
+      "resolved": "ghcr.io/rails/devcontainer/features/postgres-client@sha256:dc995acf6d691de8fc2dcc88fede02c55df608aa9de17cfa4b38de06903d7715",
+      "integrity": "sha256:dc995acf6d691de8fc2dcc88fede02c55df608aa9de17cfa4b38de06903d7715"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,16 @@
 {
-  "image": "ghcr.io/rails/devcontainer/images/ruby:3.4.8",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "runArgs": ["--add-host=host.docker.internal:host-gateway"],
 
   "customizations": {
    "vscode": {
       "extensions": [
          "ms-azuretools.vscode-docker",
-         "Shopify.ruby-lsp"
+         "Shopify.ruby-lsp",
+         "openai.chatgpt",
+         "openai.codex"
       ]
    },
    "settings": {


### PR DESCRIPTION
## Summary

- build the devcontainer from the existing Dockerfile while retaining the Rails Ruby 3.4.8 base image
- add the ChatGPT and Codex VS Code extensions
- install the Codex CLI using OpenAI's official standalone installer
- commit the generated devcontainer feature lock file

## Verification

- parsed `.devcontainer/devcontainer.json` as JSON
- built `.devcontainer/Dockerfile` successfully
- verified the installed CLI with `codex --version` (0.147.0 at build time)
- ran `git diff --check`